### PR TITLE
Minor improvements

### DIFF
--- a/bin/create-vk-mini-app.js
+++ b/bin/create-vk-mini-app.js
@@ -111,7 +111,7 @@ package-lock.json
 		//Zeit
 		if (useZeit) {
 			const nowJson = `{
-    "version": 1,
+    "version": 2,
     "name": "VK Mini App",
     "builds": [
         {

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ const App = () => {
 			}
 		});
 		async function fetchData() {
-			const user = await connect.sendPromise('VKWebAppGetUserInfo');
+			const user = await connect.send('VKWebAppGetUserInfo');
 			setUser(user);
 			setPopout(null);
 		}


### PR DESCRIPTION
- Заменил `.sendPromise` на `.send`, потому что в vk-connect@1.8.3 оно deprecated

- Поменял версию для now билдера, так как из-за того, что в билдере указана версия 1, билдер кидает уродливую ошибку 

```
Error! The property `builds` is only allowed on Now 2.0 — please upgrade: https://zeit.co/upgrade
```
Поменяв на версию 2, все деплоится