### PR TITLE
Added requirement for installed Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # Create VK Mini App [![npm][npm]][npm-url] [![deps][deps]][deps-url]
 
+## Software requirements
+
+Node.js v14.15.0 LTS or later LTS release
+
 ## How to use
 
 ### With NPX


### PR DESCRIPTION
So that users no longer try to run the `create-vk-mini-app` on an unsupported Node.js build.

The problem was solved by [Mikhail Mustakimov](https://vk.com/id.xhtml), and I just create a request :)