### PR TITLE
Импорт createRoot из пакета react-dom/client

### DIFF
--- a/templates/javascript/vkui-bridge-router/src/main.js
+++ b/templates/javascript/vkui-bridge-router/src/main.js
@@ -1,10 +1,10 @@
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import vkBridge from '@vkontakte/vk-bridge';
 import { AppConfig } from './AppConfig.js';
 
 vkBridge.send('VKWebAppInit');
 
-ReactDOM.createRoot(document.getElementById('root')).render(<AppConfig />);
+createRoot(document.getElementById('root')).render(<AppConfig />);
 
 if (import.meta.env.MODE === 'development') {
   import('./eruda.js');

--- a/templates/javascript/vkui-bridge/src/main.js
+++ b/templates/javascript/vkui-bridge/src/main.js
@@ -1,10 +1,10 @@
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import vkBridge from '@vkontakte/vk-bridge';
 import { AppConfig } from './AppConfig';
 
 vkBridge.send('VKWebAppInit');
 
-ReactDOM.createRoot(document.getElementById('root')).render(<AppConfig />);
+createRoot(document.getElementById('root')).render(<AppConfig />);
 
 if (import.meta.env.MODE === 'development') {
   import('./eruda.js');

--- a/templates/javascript/vkui-only/src/main.js
+++ b/templates/javascript/vkui-only/src/main.js
@@ -1,8 +1,8 @@
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import { ConfigProvider, AdaptivityProvider, AppRoot } from '@vkontakte/vkui';
 import { App } from './App';
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById('root')).render(
   <ConfigProvider>
     <AdaptivityProvider>
       <AppRoot>

--- a/templates/typescript/vkui-bridge-router/src/main.tsx
+++ b/templates/typescript/vkui-bridge-router/src/main.tsx
@@ -1,10 +1,10 @@
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import vkBridge from '@vkontakte/vk-bridge';
 import { AppConfig } from './AppConfig.tsx';
 
 vkBridge.send('VKWebAppInit');
 
-ReactDOM.createRoot(document.getElementById('root')!).render(<AppConfig />);
+createRoot(document.getElementById('root')!).render(<AppConfig />);
 
 if (import.meta.env.MODE === 'development') {
   import('./eruda.ts');

--- a/templates/typescript/vkui-bridge/src/main.tsx
+++ b/templates/typescript/vkui-bridge/src/main.tsx
@@ -1,11 +1,11 @@
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import vkBridge from '@vkontakte/vk-bridge';
 
 import { AppConfig } from './AppConfig.tsx';
 
 vkBridge.send('VKWebAppInit');
 
-ReactDOM.createRoot(document.getElementById('root')!).render(<AppConfig />);
+createRoot(document.getElementById('root')!).render(<AppConfig />);
 
 if (import.meta.env.MODE === 'development') {
   import('./eruda.ts');

--- a/templates/typescript/vkui-only/src/main.tsx
+++ b/templates/typescript/vkui-only/src/main.tsx
@@ -1,8 +1,8 @@
-import ReactDOM from 'react-dom/client';
+import { createRoot} from 'react-dom/client';
 import { App } from './App';
 import { AdaptivityProvider, AppRoot, ConfigProvider } from '@vkontakte/vkui';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById('root')!).render(
   <ConfigProvider>
     <AdaptivityProvider>
       <AppRoot>

--- a/templates/typescript/vkui-only/src/main.tsx
+++ b/templates/typescript/vkui-only/src/main.tsx
@@ -1,4 +1,4 @@
-import { createRoot} from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { AdaptivityProvider, AppRoot, ConfigProvider } from '@vkontakte/vkui';
 


### PR DESCRIPTION
Исправил импорт на:
```js
import { createRoot } from 'react-dom/client';
```
Причина: 
у `react-dom/client` нет дефолтного экспорта.