### PR TITLE
MA-21200: delete devtools token on pr

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
 
       - name: Setting up the repository environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Описание проблемы

Падает pr от сторонних разработчиков, у сторонних разработчиков нет secrets.DEVTOOLS_GITHUB_TOKEN

## Описание решения

token в actions/checkout@v4, начиная с 4 версии не является обязательным параметром
если он не передан, action используется встроенный GITHUB_TOKEN, который предоставляет Github Actions.
Тестирование гипотезы
